### PR TITLE
Removed: 'runChangeTracker=true' SourceMetere parameter

### DIFF
--- a/src/sonarqube-analyzers/sourcemeter-analyzer-base/src/main/java/com/sourcemeter/analyzer/base/visitor/LogicalTreeLoaderVisitor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-base/src/main/java/com/sourcemeter/analyzer/base/visitor/LogicalTreeLoaderVisitor.java
@@ -54,7 +54,6 @@ public abstract class LogicalTreeLoaderVisitor extends BaseVisitor {
     protected long logicalTime;
     protected final FileSystem fileSystem;
     protected final Settings settings;
-    protected final boolean skipTUID;
 
     protected static final Logger LOG = LoggerFactory.getLogger(LogicalTreeLoaderVisitor.class);
 
@@ -70,8 +69,6 @@ public abstract class LogicalTreeLoaderVisitor extends BaseVisitor {
         this.settings = settings;
 
         this.numOfNodes = numOfNodes;
-
-        this.skipTUID = settings.getBoolean("sm." + pluginLanguageKey + ".skipTUID");
 
         FilePredicate mainFilePredicate = fileSystem.predicates().hasType(InputFile.Type.MAIN);
 

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-cpp/src/main/java/com/sourcemeter/analyzer/cpp/SourceMeterAnalyzerCppPlugin.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-cpp/src/main/java/com/sourcemeter/analyzer/cpp/SourceMeterAnalyzerCppPlugin.java
@@ -84,14 +84,6 @@ import com.sourcemeter.analyzer.cpp.profile.SourceMeterCppRuleRepository;
                  defaultValue = SourceMeterAnalyzerCppPlugin.FALSE
              ),
              @Property(
-                 key = "sm.cpp.skipTUID",
-                 name = "Skip elements which does not have a TUID in result graph.",
-                 global = false,
-                 project = false,
-                 type = PropertyType.BOOLEAN,
-                 defaultValue = SourceMeterAnalyzerCppPlugin.TRUE
-             ),
-             @Property(
                  key = "sm.cpp.toolchainOptions",
                  name = "Add additional parameters for running SourceMeter C/C++ toolchain.",
                  global = false,

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-cpp/src/main/java/com/sourcemeter/analyzer/cpp/batch/SourceMeterCppSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-cpp/src/main/java/com/sourcemeter/analyzer/cpp/batch/SourceMeterCppSensor.java
@@ -332,7 +332,6 @@ public class SourceMeterCppSensor extends SourceMeterSensor {
         this.commands.add("-projectName=" + projectName);
         this.commands.add("-projectBaseDir=" + baseDir);
         this.commands.add("-buildScript=" + pathToBuild);
-        this.commands.add("-runChangeTracker=true");
 
         String cloneGenealogy = this.settings.getString("sm.cloneGenealogy");
         String cloneMinLines = this.settings.getString("sm.cloneMinLines");

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/SourceMeterAnalyzerCSharpPlugin.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/SourceMeterAnalyzerCSharpPlugin.java
@@ -106,14 +106,6 @@ import com.sourcemeter.analyzer.csharp.profile.SourceMeterCSharpRuleRepository;
                  defaultValue = SourceMeterAnalyzerCSharpPlugin.FALSE
              ),
              @Property(
-                 key = "sm.csharp.skipTUID",
-                 name = "Skip elements which does not have a TUID in result graph.",
-                 global = false,
-                 project = false,
-                 type = PropertyType.BOOLEAN,
-                 defaultValue = SourceMeterAnalyzerCSharpPlugin.TRUE
-             ),
-             @Property(
                  key = "sm.csharp.toolchainOptions",
                  name = "Add additional parameters for running SourceMeter C# toolchain.",
                  global = false,

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
@@ -351,7 +351,6 @@ public class SourceMeterCSharpSensor extends SourceMeterSensor {
         this.commands.add("-projectName=" + projectName);
         this.commands.add("-configuration=" + configuration);
         this.commands.add("-platform=" + platform);
-        this.commands.add("-runChangeTracker=true");
 
         String cloneGenealogy = this.settings.getString("sm.cloneGenealogy");
         String cloneMinLines = this.settings.getString("sm.cloneMinLines");

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-java/src/main/java/com/sourcemeter/analyzer/java/SourceMeterAnalyzerJavaPlugin.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-java/src/main/java/com/sourcemeter/analyzer/java/SourceMeterAnalyzerJavaPlugin.java
@@ -169,14 +169,6 @@ import com.sourcemeter.analyzer.java.profile.SourceMeterJavaRuleRepository;
                  project = false,
                  type = PropertyType.STRING
              ),
-             @Property(
-                 key = "sm.java.skipTUID",
-                 name = "Skip elements which does not have a TUID in result graph.",
-                 global = false,
-                 project = false,
-                 type = PropertyType.BOOLEAN,
-                 defaultValue = SourceMeterAnalyzerJavaPlugin.TRUE
-             )
 })
 public final class SourceMeterAnalyzerJavaPlugin implements Plugin {
 

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-java/src/main/java/com/sourcemeter/analyzer/java/batch/SourceMeterJavaSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-java/src/main/java/com/sourcemeter/analyzer/java/batch/SourceMeterJavaSensor.java
@@ -470,8 +470,6 @@ public class SourceMeterJavaSensor extends SourceMeterSensor {
             this.commands.add("-runFB=true");
         }
 
-        this.commands.add("-runChangeTracker=true");
-
         String findBugsOptions = this.settings.getString("sm.java.fbOptions");
         if (findBugsOptions != null) {
             this.commands.add("-FBOptions=" + findBugsOptions);

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-python/src/main/java/com/sourcemeter/analyzer/python/SourceMeterAnalyzerPythonPlugin.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-python/src/main/java/com/sourcemeter/analyzer/python/SourceMeterAnalyzerPythonPlugin.java
@@ -80,14 +80,6 @@ import com.sourcemeter.analyzer.python.profile.SourceMeterPythonRuleRepository;
                  project = false,
                  type = PropertyType.STRING
              ),
-             @Property(
-                 key = "sm.python.skipTUID",
-                 name = "Skip elements which does not have a TUID in result graph.",
-                 global = false,
-                 project = false,
-                 type = PropertyType.BOOLEAN,
-                 defaultValue = SourceMeterAnalyzerPythonPlugin.TRUE
-             )
 })
 public class SourceMeterAnalyzerPythonPlugin implements Plugin {
 

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-python/src/main/java/com/sourcemeter/analyzer/python/batch/SourceMeterPythonSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-python/src/main/java/com/sourcemeter/analyzer/python/batch/SourceMeterPythonSensor.java
@@ -328,7 +328,6 @@ public class SourceMeterPythonSensor extends SourceMeterSensor {
         this.commands.add("-resultsDir=" + resultsDir);
         this.commands.add("-projectName=" + projectName);
         this.commands.add("-python27binary=" + pythonBinary);
-        this.commands.add("-runChangeTracker=true");
 
         String cloneGenealogy = this.settings.getString("sm.cloneGenealogy");
         String cloneMinLines = this.settings.getString("sm.cloneMinLines");

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-rpg/src/main/java/com/sourcemeter/analyzer/rpg/SourceMeterAnalyzerRPGPlugin.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-rpg/src/main/java/com/sourcemeter/analyzer/rpg/SourceMeterAnalyzerRPGPlugin.java
@@ -90,14 +90,6 @@ import com.sourcemeter.analyzer.rpg.profile.SourceMeterRPGRuleRepository;
                      defaultValue = "false"
              ),
              @Property(
-                 key = "sm.python.skipTUID",
-                 name = "Skip elements which does not have a TUID in result graph.",
-                 global = false,
-                 project = false,
-                 type = PropertyType.BOOLEAN,
-                 defaultValue = SourceMeterAnalyzerRPGPlugin.TRUE
-             ),
-             @Property(
                      key = "sm.rpg.toolchainOptions",
                      name = "Add additional parameters for running SourceMeter RPG toolchain.",
                      global = false,

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-rpg/src/main/java/com/sourcemeter/analyzer/rpg/batch/SourceMeterRPGSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-rpg/src/main/java/com/sourcemeter/analyzer/rpg/batch/SourceMeterRPGSensor.java
@@ -304,7 +304,6 @@ public class SourceMeterRPGSensor extends SourceMeterSensor {
         this.commands.add("-projectBaseDir=" + baseDir);
         this.commands.add("-resultsDir=" + this.resultsDir);
         this.commands.add("-projectName=" + this.projectName);
-        this.commands.add("-runChangeTracker=true");
 
         String cleanResults = this.settings.getString("sm.cleanresults");
         this.commands.add("-cleanResults=" + cleanResults);


### PR DESCRIPTION
Removed: `runChangeTracker=true` and `skipTUID` SourceMetere parameters because they are useless