### PR TITLE
sm.[lang].toolchainOptions should be the last

### DIFF
--- a/src/sonarqube-analyzers/sourcemeter-analyzer-cpp/src/main/java/com/sourcemeter/analyzer/cpp/batch/SourceMeterCppSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-cpp/src/main/java/com/sourcemeter/analyzer/cpp/batch/SourceMeterCppSensor.java
@@ -322,12 +322,12 @@ public class SourceMeterCppSensor extends SourceMeterSensor {
             this.commands.add("-externalHardFilter=" + hardFilter);
         }
 
+        addCommonCommandlineOptions();
+
         String additionalParameters = FileHelper.getStringFromConfiguration(configuration, "sm.cpp.toolchainOptions");
         if (null != additionalParameters) {
             this.commands.add(additionalParameters);
         }
-
-        addCommonCommandlineOptions();
 
         return true;
     }

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
@@ -337,12 +337,12 @@ public class SourceMeterCSharpSensor extends SourceMeterSensor {
             this.commands.add("-externalHardFilter=" + hardFilter);
         }
 
+        addCommonCommandlineOptions();
+
         String additionalParameters = FileHelper.getStringFromConfiguration(this.configuration, "sm.csharp.toolchainOptions");
         if (null != additionalParameters) {
             this.commands.add(additionalParameters);
         }
-
-        addCommonCommandlineOptions();
 
         return true;
     }

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-java/src/main/java/com/sourcemeter/analyzer/java/batch/SourceMeterJavaSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-java/src/main/java/com/sourcemeter/analyzer/java/batch/SourceMeterJavaSensor.java
@@ -416,12 +416,12 @@ public class SourceMeterJavaSensor extends SourceMeterSensor {
             this.commands.add("-FBOptions=" + findBugsOptions);
         }
 
+        addCommonCommandlineOptions();
+
         String additionalParameters = FileHelper.getStringFromConfiguration(this.configuration, "sm.java.toolchainOptions");
         if (additionalParameters != null) {
             this.commands.add(additionalParameters);
         }
-
-        addCommonCommandlineOptions();
 
         return true;
     }

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-javascript/src/main/java/com/sourcemeter/analyzer/javascript/batch/SourceMeterJavaScriptSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-javascript/src/main/java/com/sourcemeter/analyzer/javascript/batch/SourceMeterJavaScriptSensor.java
@@ -297,12 +297,12 @@ public class SourceMeterJavaScriptSensor extends SourceMeterSensor {
             this.commands.add("-externalHardFilter=" + hardFilter);
         }
 
+        addCommonCommandlineOptions();
+
         String additionalParameters = FileHelper.getStringFromConfiguration(configuration, "sm.javascript.toolchainOptions");
         if (null != additionalParameters) {
             this.commands.add(additionalParameters);
         }
-
-        addCommonCommandlineOptions();
 
         return true;
     }

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-python/src/main/java/com/sourcemeter/analyzer/python/batch/SourceMeterPythonSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-python/src/main/java/com/sourcemeter/analyzer/python/batch/SourceMeterPythonSensor.java
@@ -314,12 +314,12 @@ public class SourceMeterPythonSensor extends SourceMeterSensor {
             this.commands.add("-externalHardFilter=" + filterFilePath);
         }
 
+        addCommonCommandlineOptions();
+
         String additionalParameters = FileHelper.getStringFromConfiguration(this.configuration, "sm.python.toolchainOptions");
         if (additionalParameters != null) {
             this.commands.add(additionalParameters);
         }
-
-        addCommonCommandlineOptions();
 
         return true;
     }

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-rpg/src/main/java/com/sourcemeter/analyzer/rpg/batch/SourceMeterRPGSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-rpg/src/main/java/com/sourcemeter/analyzer/rpg/batch/SourceMeterRPGSensor.java
@@ -293,11 +293,6 @@ public class SourceMeterRPGSensor extends SourceMeterSensor {
         String rpg4Pattern = FileHelper.getStringFromConfiguration(configuration, "sm.rpg.rpg4Pattern");
         this.commands.add("-rpg4FileNamePattern=" + rpg4Pattern);
 
-        String additionalParameters = FileHelper.getStringFromConfiguration(configuration, "sm.rpg.toolchainOptions");
-        if (additionalParameters != null) {
-            this.commands.add(additionalParameters);
-        }
-
         String hardFilter = "";
         String hardFilterFilePath = null;
         hardFilter = getFilterContent(sensorContext, RPG.KEY);
@@ -325,6 +320,11 @@ public class SourceMeterRPGSensor extends SourceMeterSensor {
         }
 
         addCommonCommandlineOptions();
+
+        String additionalParameters = FileHelper.getStringFromConfiguration(configuration, "sm.rpg.toolchainOptions");
+        if (additionalParameters != null) {
+            this.commands.add(additionalParameters);
+        }
 
         return true;
     }


### PR DESCRIPTION
sm.[lang].toolchainOptions should be the last property added to the
toolchain, because this will override the default toolchain options,
provide more flexibility for the user