### PR TITLE
Clone Viewer code context gets cleared when the selected instance cha…

### DIFF
--- a/src/sonarqube-gui-plugin/src/main/resources/static/js/cloneViewer/SideBySideDiffer.js
+++ b/src/sonarqube-gui-plugin/src/main/resources/static/js/cloneViewer/SideBySideDiffer.js
@@ -317,7 +317,7 @@ SM.SideBySideDiffer = function(HTMLelem, options) {
    * @param {index} id  id==0 for the left, id==1 for the right pane
    * @param {CloneInstance} selectedInstance the cloneinstance object that is displayed in the pane
    */
-  this.setInstance = function (id, selectedInstance) {
+  this.setInstance = function (id, selectedInstance, clearOther = true) {
     if (id >= this.text.length) {
       throw "IndexOutOfBoundsException";
       return;
@@ -341,6 +341,11 @@ SM.SideBySideDiffer = function(HTMLelem, options) {
       start,
       stop
     );
+
+    // clear context of the other instance
+    if (clearOther && typeof this.instance[1-id] != "undefined") {
+      this.setInstance(1-id, this.instance[1-id], false);
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes following bug (clone viewer context bug):

prerequisite: naviage to  the clone viewer page.
steps to reproduce: 
 1. click on both top and bottom clone context buttons, to show context for the instances.
 2. Then change the second selected clone instance 

what happens:
![Clipboard - 2020  június 11  10_51](https://user-images.githubusercontent.com/18302198/84384830-ddcd3200-abee-11ea-9553-11729e4052c6.png)

what should happen:
context on both instances should reset.