### PR TITLE
darkened bg color of even table rows

### DIFF
--- a/src/sonarqube-gui-plugin/src/main/resources/static/css/sm-widget.css
+++ b/src/sonarqube-gui-plugin/src/main/resources/static/css/sm-widget.css
@@ -84,12 +84,12 @@ div.sm-widget .control-filter-input {
 }
 
 .sm-widget table tr:nth-child(2n) {
-  background-color: #f5f5f5;
+  background-color: #e7e7e7;
 }
 
 /*row coloring for clone table*/
 .sm-widget table td.sm-widget-row-odd {
-  background-color: #f5f5f5;
+  background-color: #e7e7e7;
 }
 .sm-widget table td.sm-widget-row-even {
   background-color: #fff


### PR DESCRIPTION
On some monitors, depending on the brightness settings the odd-even line background colors cant be distinguished. These changes increase the contrast between the odd-even lines.