### PR TITLE
56 fix csharp filter path for linux

### DIFF
--- a/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -414,7 +415,11 @@ public class SourceMeterCSharpSensor extends SourceMeterSensor {
         for (InputFile file : sourceFilesForProject) {
             String path = file.uri().normalize().getPath();
             filter.append("+");
-            filter.append(path.substring(1).replaceAll("/", "\\\\\\\\"));
+            if (system.isOsWindows()) {
+                filter.append(path.substring(1).replaceAll("/", "\\\\\\\\")); // TODO: check if really needed that much or the super defined method could be used.
+            } else {
+                filter.append(Pattern.quote(path));
+            }
             filter.append("\n");
         }
         return filter.toString();

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
@@ -416,7 +416,7 @@ public class SourceMeterCSharpSensor extends SourceMeterSensor {
             String path = file.uri().normalize().getPath();
             filter.append("+");
             if (system.isOsWindows()) {
-                filter.append(path.substring(1).replaceAll("/", "\\\\\\\\")); // TODO: check if really needed that much or the super defined method could be used.
+                filter.append(path.substring(1).replaceAll("/", "\\\\\\\\"));
             } else {
                 filter.append(Pattern.quote(path));
             }

--- a/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
+++ b/src/sonarqube-analyzers/sourcemeter-analyzer-csharp/src/main/java/com/sourcemeter/analyzer/csharp/batch/SourceMeterCSharpSensor.java
@@ -301,7 +301,7 @@ public class SourceMeterCSharpSensor extends SourceMeterSensor {
 
         String csharpKey = CSharp.KEY.toUpperCase(Locale.ENGLISH);
         if ("CS".equals(csharpKey)) {
-            csharpKey = "CSHARP";
+            csharpKey = "CSharp";
         }
 
         this.commands.add(pathToCA + File.separator


### PR DESCRIPTION
This PR closes https://github.com/FrontEndART/SonarQube-plug-in/issues/56

The C# analyzer now supports Linux,, thus the filepaths should be handled that way too.
The analyzer is in CSharps folder not in CSHARP that is important for Linux. There were no difference for windows.